### PR TITLE
Auto Configure MISP

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,8 @@ Collects logs from an instance of the JiscCTI/misp-docker Docker project.
     * `SPLUNK_PASSWORD` A password to use when creating the admin account on the Splunk Universal Forwarder.
     * `SPLUNK_HEC_URI` The same HTTP Event Collector URI configured in Docker.
     * `SPLUNK_HEC_KEY` The same HTTP Event Collector key configured in Docker.
-    * `SPLUNK_HEC_SSL` Case-sensitive `true` or `false` for if HTTPS is needed for the HTTP Event Collector.
     * `SPLUNK_HEC_VERIFY` Case-sensitive `true` or `false` for whether HTTPS certificate should be verified for the HTTP
         Event Collector.
     * `SPLUNK_INDEX` The index logs should be written to.
-    * `SPLUNK_MISP_AUTHKEY` An AuthKey from MISP which can read logs, e.g. from an account with the `admin` role.
-    * `SPLUNK_MISP_VERIFY` Case-sensitive `true` or `false` for whether HTTPS certificate should be verified for MISP.
 3. Add the `splunk_forwarder` services from `docker-compose-snip.yml` to your `docker-compose.yml` file.
 4. Start the Universal Forwarder: `docker compose up -d`

--- a/app/README/misp_docker.conf.example
+++ b/app/README/misp_docker.conf.example
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-[default]
-baseurl = https://misp.example.com
-authkey = 000111222333444555666777888999aaabbcccdd
-verifytls = False
-
 [misp_user_logs]
-lastrun = 0
-lastid = 0
+LastRun = 0
+LastId = 0

--- a/app/README/misp_docker.conf.spec
+++ b/app/README/misp_docker.conf.spec
@@ -12,19 +12,6 @@
 #
 # No Splunk restart is needed for changes to take effect.
 
-[default]
-BaseUrl = <string>
-* required
-* The Base URL of the MISP instance logs will be collected from
-
-AuthKey = <string>
-* required
-* An authentication key for MISP with permission to read logs
-
-VerifyTls = <boolean>
-* required
-* Whether to verify MISPs TLS certificate
-
 [misp_user_logs]
 LastRun = <number>
 * The last time the User log script was run, as a UNIX epoch float

--- a/configure.py
+++ b/configure.py
@@ -25,20 +25,7 @@ parser.add_argument("-hk", "--hec-key", required=True, dest="hecKey")
 parser.add_argument(
     "-hv", "--hec-verify", choices=["true", "false"], required=True, dest="hecVerify"
 )
-parser.add_argument(
-    "-hs", "--hec-ssl", choices=["true", "false"], required=True, dest="hecSsl"
-)
 parser.add_argument("-in", "--index", required=True, dest="index")
-# MISP options
-parser.add_argument("-mu", "--misp-uri", required=True, dest="mispUri")
-parser.add_argument("-mk", "--misp-key", required=True, dest="mispKey")
-parser.add_argument(
-    "-mv",
-    "--misp-verify",
-    choices=["true", "false"],
-    required=True,
-    dest="mispVerify",
-)
 # Input options
 parser.add_argument("-f", "--fqdn", required=True, dest="fqdn")
 
@@ -48,12 +35,6 @@ if args.hecUri in ("", "https://splunk.example.com:8088"):
     raise ValueError("HEC_URI not configured, cannot start.")
 if args.hecKey in ("", "00000000-1111-2222-3333-444444444444"):
     raise ValueError("HEC_KEY not configured, cannot start.")
-if args.mispUri.startswith("https://:") or args.mispUri.startswith(
-    "https://misp.example.com:"
-):
-    raise ValueError("(MISP) FQDN not configured, cannot start.")
-if args.mispKey in ("", "000111222333444555666777888999aaabbcccdd"):
-    raise ValueError("MISP_KEY not configured, cannot start.")
 if args.fqdn in ("", "misp.example.com"):
     raise ValueError("(MISP) FQDN not configured, cannot start.")
 
@@ -78,17 +59,6 @@ outputs.set("httpout", "httpEventCollectorToken", args.hecKey)
 outputs.set("httpout", "uri", args.hecUri)
 outputs.set("httpout", "sslVerifyServerCert", args.hecVerify)
 outputs.set("httpout", "sslVerifyServerName", args.hecVerify)
-outputs.set("httpout", "useSSL", args.hecSsl)
+outputs.set("httpout", "useSSL", str(args.hecUri.startswith("https://")).lower())
 with open(outputsConf, "w") as f:
     outputs.write(f)
-
-appConf = "/opt/splunkforwarder/etc/apps/misp_docker/local/misp_docker.conf"
-app = ConfigParser()
-app.read(appConf)
-if "default" not in app.sections():
-    app.add_section("default")
-app.set("default", "baseUrl", args.mispUri)
-app.set("default", "authKey", args.mispKey)
-app.set("default", "verifyTls", args.mispVerify)
-with open(appConf, "w") as f:
-    app.write(f)

--- a/docker-compose-snip.yml
+++ b/docker-compose-snip.yml
@@ -16,13 +16,11 @@ services:
       - SPLUNK_START_ARGS=--accept-license
       - HEC_URI=${SPLUNK_HEC_URI}
       - HEC_KEY=${SPLUNK_HEC_KEY}
-      - HEC_SSL=${SPLUNK_HEC_SSL:-true}
       - HEC_VERIFY=${SPLUNK_HEC_VERIFY:-false}
       - INDEX=${SPLUNK_INDEX:-default}
-      - MISP_KEY=${SPLUNK_MISP_AUTHKEY}
-      - MISP_VERIFY=${SPLUNK_MISP_VERIFY:-false}
     volumes:
-      - ./persistent/${COMPOSE_PROJECT_NAME}/splunk/config/:/opt/splunkforwarder/etc/apps/misp_docker/local/
+      - ./persistent/${COMPOSE_PROJECT_NAME}/splunk/config/:/opt/splunkforwarder/etc/apps/misp_docker/local
+      - ./persistent/${COMPOSE_PROJECT_NAME}/data:/opt/misp_docker:ro
       # persist the fishbucket so log entries are not reingested on restart
       - ./persistent/${COMPOSE_PROJECT_NAME}/splunk/fishbucket/:/opt/splunkforwarder/var/lib/splunk/fishbucket
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/tmp/logs/:/var/logs/MISP

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,10 +28,7 @@ set -e
 
 config_app() {
     sudo /bin/python /sbin/configure.py \
-        --hec-uri "$HEC_URI" --hec-key "$HEC_KEY" --hec-verify "$HEC_VERIFY" --hec-ssl "$HEC_SSL"\
-        --misp-uri "https://$FQDN:$HTTPS_PORT" --misp-key "$MISP_KEY" --misp-verify "$MISP_VERIFY"\
-        --fqdn "$FQDN" --index "$INDEX"
-    sudo chown -R splunk:splunk /opt/splunkforwarder
+        --hec-uri "$HEC_URI" --hec-key "$HEC_KEY" --hec-verify "$HEC_VERIFY" --index "$INDEX" --fqdn "$FQDN"
 }
 
 setup() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ setup() {
 
 teardown() {
         # Always run the stop command on termination
-        if [ `whoami` != "${SPLUNK_USER}" ]; then
+        if [ "$(whoami)" != "${SPLUNK_USER}" ]; then
                 RUN_AS_SPLUNK="sudo -u ${SPLUNK_USER}"
         fi
         ${RUN_AS_SPLUNK} ${SPLUNK_HOME}/bin/splunk stop || true
@@ -53,7 +53,7 @@ trap teardown SIGINT SIGTERM
 
 prep_ansible() {
         cd ${SPLUNK_ANSIBLE_HOME}
-        if [ `whoami` == "${SPLUNK_USER}" ]; then
+        if [ "$(whoami)" == "${SPLUNK_USER}" ]; then
                 sed -i -e "s,^become\\s*=.*,become = false," ansible.cfg
         fi
         if [[ "$DEBUG" == "true" ]]; then
@@ -73,7 +73,7 @@ watch_for_failure(){
         echo Ansible playbook complete, will begin streaming var/log/splunk/splunkd_stderr.log
         echo
         user_permission_change
-        if [ `whoami` != "${SPLUNK_USER}" ]; then
+        if [ "$(whoami)" != "${SPLUNK_USER}" ]; then
                 RUN_AS_SPLUNK="sudo -u ${SPLUNK_USER}"
         fi
         # Any crashes/errors while Splunk is running should get logged to splunkd_stderr.log and sent to the container's stdout

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,13 +46,13 @@ teardown() {
         if [ "$(whoami)" != "${SPLUNK_USER}" ]; then
                 RUN_AS_SPLUNK="sudo -u ${SPLUNK_USER}"
         fi
-        ${RUN_AS_SPLUNK} ${SPLUNK_HOME}/bin/splunk stop || true
+        ${RUN_AS_SPLUNK} "${SPLUNK_HOME}/bin/splunk" stop || true
 }
 
 trap teardown SIGINT SIGTERM
 
 prep_ansible() {
-        cd ${SPLUNK_ANSIBLE_HOME}
+        cd "${SPLUNK_ANSIBLE_HOME}"
         if [ "$(whoami)" == "${SPLUNK_USER}" ]; then
                 sed -i -e "s,^become\\s*=.*,become = false," ansible.cfg
         fi
@@ -78,9 +78,9 @@ watch_for_failure(){
         fi
         # Any crashes/errors while Splunk is running should get logged to splunkd_stderr.log and sent to the container's stdout
         if [ -z "$SPLUNK_TAIL_FILE" ]; then
-                ${RUN_AS_SPLUNK} tail -n 0 -f ${SPLUNK_HOME}/var/log/splunk/splunkd_stderr.log &
+                ${RUN_AS_SPLUNK} tail -n 0 -f "${SPLUNK_HOME}/var/log/splunk/splunkd_stderr.log" &
         else
-                ${RUN_AS_SPLUNK} tail -n 0 -f ${SPLUNK_TAIL_FILE} &
+                ${RUN_AS_SPLUNK} tail -n 0 -f "${SPLUNK_TAIL_FILE}" &
         fi
         wait
 }
@@ -109,7 +109,7 @@ start() {
 restart(){
         sh -c "echo 'restarting' > ${CONTAINER_ARTIFACT_DIR}/splunk-container.state"
         prep_ansible
-        ${SPLUNK_HOME}/bin/splunk stop 2>/dev/null || true
+        "${SPLUNK_HOME}/bin/splunk" stop 2>/dev/null || true
         ansible-playbook -i inventory/environ.py -l localhost start.yml
         watch_for_failure
 }
@@ -171,7 +171,7 @@ case "$1" in
                 wait
                 ;;
         bash|splunk-bash)
-                /bin/bash --init-file ${SPLUNK_HOME}/bin/setSplunkEnv
+                /bin/bash --init-file "${SPLUNK_HOME}/bin/setSplunkEnv"
                 ;;
         help)
                 shift


### PR DESCRIPTION
# Description

Get MISP Base URL and Auth Key from the MISP Maintenance config file, removing the need for the Auth Key to be known at container creation time.

## Related Issue(s)

(none)

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Ubuntu 22.04.3 LTS
* Docker Engine Version: 24.0.7
* MISP Version: 2.4.178
* Splunk Version: 9.1.1

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
