### PR TITLE
MISP Event Logging

### DIFF
--- a/app/bin/misp_event_logs.py
+++ b/app/bin/misp_event_logs.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+from pathlib import Path
+from configparser import ConfigParser, NoOptionError, NoSectionError
+from datetime import datetime, timedelta, timezone
+
+import requests
+from requests.exceptions import RequestException, Timeout
+from urllib3 import disable_warnings
+from urllib3.exceptions import InsecureRequestWarning
+
+disable_warnings(InsecureRequestWarning)
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG_FILE = BASE_DIR / "default" / "misp_docker.conf"
+LOCAL_CONFIG_FILE = BASE_DIR / "local" / "misp_docker.conf"
+JOBS_CONFIG_FILE = Path("/opt/misp_docker/misp_maintenance_jobs.ini")
+
+
+def load_config(file_paths: list[Path]) -> ConfigParser:
+    config = ConfigParser()
+    config.read([str(f) for f in file_paths if f.exists()])
+    return config
+
+
+jobs_config = load_config([JOBS_CONFIG_FILE])
+app_config = load_config([DEFAULT_CONFIG_FILE, LOCAL_CONFIG_FILE])
+
+if "misp_event_logs" not in app_config.sections():
+    app_config.add_section("misp_event_logs")
+
+
+def get_config_value(config: ConfigParser, section: str, option: str, fallback=None):
+    try:
+        return config.get(section, option)
+    except (NoOptionError, NoSectionError):
+        return fallback
+
+
+def fetch_misp_events():
+    misp_url = "https://web:443"
+    auth_key = get_config_value(jobs_config, "DEFAULT", "AuthKey")
+    verify_tls = jobs_config.getboolean("DEFAULT", "VerifyTls", fallback=False)
+
+    if not misp_url or not auth_key:
+        error_event = {"error": "MISP_URL or AuthKey not set in configuration"}
+        print(json.dumps(error_event), file=sys.stderr)
+        sys.exit(1)
+
+    headers = {
+        "Authorization": auth_key,
+        "Accept": "application/json",
+        "Content-type": "application/json",
+        "User-Agent": "misp_event_logs/1.0.0",
+    }
+
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+    payload = {"returnFormat": "json", "date_from": yesterday}
+    url = f"{misp_url}/events/restSearch"
+
+    try:
+        response = requests.post(url, headers=headers, json=payload, verify=verify_tls, timeout=10)
+        response.raise_for_status()
+    except Timeout:
+        error_event = {"error": "Request timed out"}
+        print(json.dumps(error_event), file=sys.stderr)
+        sys.exit(1)
+    except RequestException as e:
+        error_event = {"error": f"Request failed: {e}"}
+        print(json.dumps(error_event), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        data = response.json()
+    except ValueError:
+        error_event = {"error": "Failed to parse JSON response"}
+        print(json.dumps(error_event), file=sys.stderr)
+        sys.exit(1)
+
+    events = data.get("response", [])
+    if not events:
+        return
+
+    for e in events:
+        event = e.get("Event", {})
+        output = {
+            "id": event.get("id"),
+            "info": event.get("info"),
+            "date": event.get("date"),
+            "org": event.get("Orgc", {}).get("name")
+        }
+        print(json.dumps(output))
+
+
+fetch_misp_events()

--- a/app/default/inputs.conf
+++ b/app/default/inputs.conf
@@ -60,3 +60,10 @@ interval = 60
 sourcetype = _json
 python.version = python3
 source = misp_user_logs.py
+
+[script://$SPLUNK_HOME/etc/apps/misp_docker/bin/misp_event_logs.py]
+# Run every 24 hours
+interval = 86400
+sourcetype = _json
+python.version = python3
+source = misp_event_logs.py


### PR DESCRIPTION
# Description

This commit adds in a script that queries MISP for the events in the instance every 24 hours and sends this information to Splunk. This is useful if you are wanting to see the breakdown of events per organisation in your instance. 

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] GitHub Actions Development Images passing.
- [X] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Ubuntu 6.14.0-33-generic
* Docker Engine Version: 28.4.0
* MISP Version: 2.5.22
* Splunk Version: 10.0.1

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
